### PR TITLE
Docker server images

### DIFF
--- a/deploy/compose/docker-compose-ingestor-server.yaml
+++ b/deploy/compose/docker-compose-ingestor-server.yaml
@@ -3,7 +3,6 @@ services:
   # Main ingestor server which is responsible for ingestion
   ingestor-server:
     container_name: ingestor-server
-    image: nvcr.io/nvidia/blueprint/ingestor-server:${TAG:-2.3.0}
     build:
       # Set context to repo's root directory
       context: ../../

--- a/deploy/compose/docker-compose-rag-server.yaml
+++ b/deploy/compose/docker-compose-rag-server.yaml
@@ -3,7 +3,6 @@ services:
   # Main orchestrator server which stiches together all calls to different services to fulfill the user request
   rag-server:
     container_name: rag-server
-    image: nvcr.io/nvidia/blueprint/rag-server:${TAG:-2.3.0}
     build:
       # Set context to repo's root directory
       context: ../../

--- a/docs/deploy-docker-nvidia-hosted.md
+++ b/docs/deploy-docker-nvidia-hosted.md
@@ -190,7 +190,7 @@ Use the following procedure to start all containers needed for this blueprint.
    compose-redis-1                         Up 5 minutes
    rag-frontend                            Up 9 minutes
    rag-server                              Up 9 minutes
-   cyborgdb-redis                          Up 36 minutes (healthy)
+   cyborgdb-postgres                       Up 36 minutes (healthy)
    cyborgdb                                Up 35 minutes (healthy)
    minio                                   Up 35 minutes (healthy)
    ```


### PR DESCRIPTION
This PR removes the reference to the cloud hosted rag server and ingestor server images so that we don't have to specify --build every time we run the docker containers. they will now always build